### PR TITLE
Use -march=native with g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXXFLAGS=--std=c++11 -W -Wall -O3 -DNDEBUG
+CXXFLAGS=--std=c++11 -W -Wall -O3 -march=native -DNDEBUG
 
 SRCS=Solver.cpp
 OBJS=$(subst .cpp,.o,$(SRCS))


### PR DESCRIPTION
On my computer the Middle-Medium strong solver test gets faster from
3.43ms to 3.20ms on average time with gcc 9.3.0 in Ubuntu 18.04 on Intel(R) Xeon(R) CPU E3-1505M v6 @ 3.00GHz.